### PR TITLE
nerfed HE502 stats

### DIFF
--- a/Blasphemous.LostDreams/Swords/HE502.cs
+++ b/Blasphemous.LostDreams/Swords/HE502.cs
@@ -34,7 +34,7 @@ public class HE502 : IToggleEffect
 
     public class Config
     {
-        public float STANDARD_MULTIPLIER { get; set; } = 0.8f;
-        public float SWORDART_MULTIPLIER { get; set; } = 1.5f;
+        public float STANDARD_MULTIPLIER { get; set; } = 0.7f;
+        public float SWORDART_MULTIPLIER { get; set; } = 1.4f;
     }
 }


### PR DESCRIPTION
nerfed HE502's standard damage multiplier 80% -> 70%, sword arts damage multiplier 150% -> 140%