### PR TITLE
`ColliderModifier` revision

### DIFF
--- a/Blasphemous.LostDreams/Levels/Modifiers.cs
+++ b/Blasphemous.LostDreams/Levels/Modifiers.cs
@@ -14,28 +14,44 @@ namespace Blasphemous.LostDreams.Levels;
 /// </summary>
 public class ColliderModifier : IModifier
 {
-    private readonly string _name;
     private readonly Vector2 _size;
+    private readonly Vector2 _offset;
 
     /// <summary>
-    /// Specify the name and size of the collider
+    /// The layer of the collider. 
+    /// For solid collider, choose layer "Floor". 
+    /// For droppable platforms, choose layer "OneWayDown"
     /// </summary>
-    public ColliderModifier(string name, Vector2 size)
+    private readonly string _layer;
+
+    /// <summary>
+    /// Specify the layer, size, and offset of of the collider
+    /// </summary>
+    public ColliderModifier(string layer, Vector2 size, Vector2 offset)
     {
-        _name = name;
+        _layer = layer;
         _size = size;
+        _offset = offset;
     }
 
     /// <summary>
-    /// Adds a collider component and sets the layer to floor
+    /// Specify the layer and size of of the collider, 
+    /// with its offset set to (0, 0)
+    /// </summary>
+    public ColliderModifier(string layer, Vector2 size)
+        : this(layer, size, new Vector2(0, 0)) { }
+
+    /// <summary>
+    /// Adds a collider component and sets the layer
     /// </summary>
     public void Apply(GameObject obj, ObjectData data)
     {
-        obj.name = _name;
-        obj.layer = LayerMask.NameToLayer("Floor");
+        obj.name = $"Collider[{data.id}]";
+        obj.layer = LayerMask.NameToLayer(_layer);
 
         var collider = obj.AddComponent<BoxCollider2D>();
         collider.size = _size;
+        collider.offset = _offset;
     }
 }
 

--- a/Blasphemous.LostDreams/LostDreams.cs
+++ b/Blasphemous.LostDreams/LostDreams.cs
@@ -106,27 +106,18 @@ public class LostDreams : BlasMod
         provider.RegisterObjectCreator("patio-bricks", new ObjectCreator(
             new SceneLoader("D04Z01S01_DECO", "MIDDLEGROUND/AfterPlayer/Arcs/garden-spritesheet_41 (6)"),
             new NoModifier("Bricks")));
-        provider.RegisterObjectCreator("patio-floor", new ObjectCreator(
-            new SceneLoader("D04Z01S01_DECO", "MIDDLEGROUND/AfterPlayer/Floor/garden-spritesheet_13 (2)"),
-            new ColliderModifier("Floor", new Vector2(2.7f, 0.4f))));
         provider.RegisterObjectCreator("npc", new ObjectCreator(
             new NpcLoader(),
             new NpcModifier()));
         provider.RegisterObjectCreator("door", new ObjectCreator(
             new SceneLoader("D17Z01S10_LOGIC", "DOORS/{0}"),
             new DoorModifier()));
-        provider.RegisterObjectCreator("wasteland-wall", new ObjectCreator(
-            new SceneLoader("D01Z03S06_DECO", "MIDDLEGROUND/AfterPlayer/SideDoor/churches-field-spritesheet-improved_73")
-            new ColliderModifier()));
         provider.RegisterObjectCreator("wasteland-stone-diagonal", new ObjectCreator(
             new SceneLoader("D01Z03S06_DECO", "MIDDLEGROUND/AfterPlayer/Walls/churches-field-spritesheet-improved_20"),
             new NoModifier("Diagonal Stone")));
         provider.RegisterObjectCreator("wasteland-stone-vertical", new ObjectCreator(
             new SceneLoader("D01Z03S06_DECO", "MIDDLEGROUND/AfterPlayer/Walls/churches-field-spritesheet-improved_25"),
             new NoModifier("Vertical Stone")));
-        provider.RegisterObjectCreator("wasteland-platform-rock", new ObjectCreator(
-            new SceneLoader("D01Z03S06_DECO", "MIDDLEGROUND/AfterPlayer/Floor/churches-field-spritesheet-improved_0"),
-            new ColliderModifier()));
         provider.RegisterObjectCreator("wasteland-tree", new ObjectCreator(
             new SceneLoader("D01Z03S06_DECO", "MIDDLEGROUND/AfterPlayer/Props/Trees/churches-field-spritesheet-improved_41"),
             new NoModifier("Wasteland Tree")));
@@ -136,5 +127,20 @@ public class LostDreams : BlasMod
         provider.RegisterObjectCreator("wasteland-rock_2", new ObjectCreator(
             new SceneLoader("D01Z03S06_DECO", "MIDDLEGROUND/AfterPlayer/Props/Rocks/churches-field-spritesheet-improved_48"),
             new NoModifier("Wasteland Rock 2")));
+
+        provider.RegisterObjectCreator("patio-floor", new ObjectCreator(
+            new SceneLoader("D04Z01S01_DECO", "MIDDLEGROUND/AfterPlayer/Floor/garden-spritesheet_13 (2)"),
+            new ColliderModifier("Floor",
+                                 new Vector2(2.9f, 0.9f),
+                                 new Vector2(0, -0.3f))));
+        provider.RegisterObjectCreator("wasteland-platform-rock", new ObjectCreator(
+            new SceneLoader("D01Z03S06_DECO", "MIDDLEGROUND/AfterPlayer/Floor/churches-field-spritesheet-improved_0"),
+            new ColliderModifier("Floor",
+                                 new Vector2(4f, 1.4f),
+                                 new Vector2(0, -0.3f))));
+        provider.RegisterObjectCreator("wasteland-wall", new ObjectCreator(
+            new SceneLoader("D01Z03S06_DECO", "MIDDLEGROUND/AfterPlayer/SideDoor/churches-field-spritesheet-improved_73"),
+            new ColliderModifier("Floor",
+                                 new Vector2(2f, 2f))));
     }
 }


### PR DESCRIPTION
Makes `ColliderModifier` auto-generate name with `data.id`

Allows setting collider layers in constructor

Revises specifications of registered objects accordingly.