### PR TITLE
filler blocks positioning

### DIFF
--- a/Blasphemous.LostDreams/Levels/Modifiers/BaseColliderModifier.cs
+++ b/Blasphemous.LostDreams/Levels/Modifiers/BaseColliderModifier.cs
@@ -1,5 +1,5 @@
-﻿using Blasphemous.Framework.Levels.Modifiers;
-using Blasphemous.Framework.Levels;
+﻿using Blasphemous.Framework.Levels;
+using Blasphemous.Framework.Levels.Modifiers;
 using UnityEngine;
 
 namespace Blasphemous.LostDreams.Levels.Modifiers;
@@ -14,12 +14,25 @@ internal abstract class BaseColliderModifier : IModifier
     /// For solid collider, choose layer "Floor". 
     /// For droppable platforms, choose layer "OneWayDown"
     /// </summary>
-    protected readonly string _layer;
+    protected string _layer;
 
     /// <summary>
     /// The offset of the collider to the attached GameObject
     /// </summary>
-    protected readonly Vector2 _offset;
+    protected Vector2 _offset;
+
+    /// <summary>
+    /// Whether the collider uses properties instead of constructor to initialize itself
+    /// </summary>
+    protected readonly bool _useProperties = false;
+
+    /// <summary>
+    /// Reads properties instead of using constructor to initialize the parameters
+    /// </summary>
+    public BaseColliderModifier()
+    {
+        _useProperties = true;
+    }
 
     /// <summary>
     /// Abstract constructor, specifying the layer and offset of the collider
@@ -35,7 +48,14 @@ internal abstract class BaseColliderModifier : IModifier
     /// </summary>
     public virtual void Apply(GameObject obj, ObjectData data)
     {
+        if (_useProperties)
+        {
+            _layer = data.properties[0];
+        }
+
         obj.name = $"Collider[{data.id}]";
         obj.layer = LayerMask.NameToLayer(_layer);
     }
+
+
 }

--- a/Blasphemous.LostDreams/Levels/Modifiers/BoxColliderModifier.cs
+++ b/Blasphemous.LostDreams/Levels/Modifiers/BoxColliderModifier.cs
@@ -8,7 +8,12 @@ namespace Blasphemous.LostDreams.Levels.Modifiers;
 /// </summary>
 internal class BoxColliderModifier : BaseColliderModifier
 {
-    private readonly Vector2 _size;
+    private Vector2 _size;
+
+    /// <summary>
+    /// Reads properties instead of using constructor to initialize the parameters
+    /// </summary>
+    public BoxColliderModifier() : base() { }
 
     /// <summary>
     /// Specify the layer, size, and offset of the collider
@@ -26,6 +31,12 @@ internal class BoxColliderModifier : BaseColliderModifier
     public override void Apply(GameObject obj, ObjectData data)
     {
         base.Apply(obj, data);
+
+        if (_useProperties)
+        {
+            _size = Main.StringToVector3(data.properties[1]);
+            _offset = Main.StringToVector3(data.properties[2]);
+        }
 
         var collider = obj.AddComponent<BoxCollider2D>();
         collider.size = _size;

--- a/Blasphemous.LostDreams/Levels/Modifiers/DoorModifier.cs
+++ b/Blasphemous.LostDreams/Levels/Modifiers/DoorModifier.cs
@@ -1,5 +1,5 @@
-﻿using Blasphemous.Framework.Levels.Modifiers;
-using Blasphemous.Framework.Levels;
+﻿using Blasphemous.Framework.Levels;
+using Blasphemous.Framework.Levels.Modifiers;
 using Framework.FrameworkCore;
 using Tools.Level.Interactables;
 using UnityEngine;

--- a/Blasphemous.LostDreams/Levels/Modifiers/NpcModifier.cs
+++ b/Blasphemous.LostDreams/Levels/Modifiers/NpcModifier.cs
@@ -1,5 +1,5 @@
-﻿using Blasphemous.Framework.Levels.Modifiers;
-using Blasphemous.Framework.Levels;
+﻿using Blasphemous.Framework.Levels;
+using Blasphemous.Framework.Levels.Modifiers;
 using Blasphemous.LostDreams.Components;
 using Blasphemous.LostDreams.Npc;
 using Gameplay.GameControllers.Entities;

--- a/Blasphemous.LostDreams/LostDreams.cs
+++ b/Blasphemous.LostDreams/LostDreams.cs
@@ -103,6 +103,9 @@ public class LostDreams : BlasMod
         provider.RegisterObjectCreator("spriterenderer", new ObjectCreator(
             new EmptyLoader("Sprite"),
             new SpriteRendererModifier()));
+        provider.RegisterObjectCreator("boxcollider", new ObjectCreator(
+            new EmptyLoader("BoxCollider2D"),
+            new BoxColliderModifier()));
 
         // Patio objects
         provider.RegisterObjectCreator("patio-column", new ObjectCreator(

--- a/Blasphemous.LostDreams/LostDreams.cs
+++ b/Blasphemous.LostDreams/LostDreams.cs
@@ -103,9 +103,12 @@ public class LostDreams : BlasMod
         provider.RegisterObjectCreator("spriterenderer", new ObjectCreator(
             new EmptyLoader("Sprite"),
             new SpriteRendererModifier()));
-        provider.RegisterObjectCreator("boxcollider", new ObjectCreator(
+        provider.RegisterObjectCreator("boxcollider-floor", new ObjectCreator(
             new EmptyLoader("BoxCollider2D"),
-            new BoxColliderModifier()));
+            new BoxColliderModifier("Floor", new Vector2(1, 1))));
+        provider.RegisterObjectCreator("boxcollider-droppable", new ObjectCreator(
+            new EmptyLoader("BoxCollider2D"),
+            new BoxColliderModifier("OneWayDown", new Vector2(1, 1))));
 
         // Patio objects
         provider.RegisterObjectCreator("patio-column", new ObjectCreator(

--- a/Blasphemous.LostDreams/Main.cs
+++ b/Blasphemous.LostDreams/Main.cs
@@ -1,5 +1,8 @@
 ﻿using BepInEx;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
 
 namespace Blasphemous.LostDreams;
 
@@ -22,5 +25,40 @@ internal class Main : BaseUnityPlugin
         return validate(obj)
             ? obj
             : throw new Exception($"{obj} is an invalid import argument");
+    }
+
+    public static Vector3 StringToVector3(string sVector)
+    {
+        // Remove the parentheses
+        sVector = sVector.Trim().TrimStart('(').TrimEnd(')');
+
+        // split the items
+        List<string> stringList = sVector.Split(',').ToList();
+
+        // convert to Vector3
+        Vector3 result;
+        while (stringList.Count < 3)
+        {
+            stringList.Add("0.0");
+        }
+        result = new Vector3(
+            StringToFloatOrDefault(stringList[0]),
+            StringToFloatOrDefault(stringList[1]),
+            StringToFloatOrDefault(stringList[2]));
+        return result;
+
+        static float StringToFloatOrDefault(string input)
+        {
+            float result;
+            try
+            {
+                result = float.Parse(input);
+            }
+            catch
+            {
+                result = 0f;
+            }
+            return result;
+        }
     }
 }

--- a/resources/levels/Lost Dreams/D01Z03S04.json
+++ b/resources/levels/Lost Dreams/D01Z03S04.json
@@ -57,6 +57,24 @@
                 "x": -191.84,
                 "y": 20.34
             }
+        },
+        {
+            "type": "spriterenderer",
+            "scale": {
+                "x": 1.6,
+                "y": 5,
+                "z": 1
+            },
+            "position": {
+                "x": -190.8,
+                "y": 22
+            },
+            "properties": [
+                "__square",
+                "Before Player",
+                "1",
+                "#1E1A1C"
+            ]
         }
     ],
     "modifications": [

--- a/resources/levels/Lost Dreams/D01Z03S06.json
+++ b/resources/levels/Lost Dreams/D01Z03S06.json
@@ -47,16 +47,16 @@
       ]
     },
     {
-      "Type": "boxcollider",
+      "Type": "boxcollider-droppable",
       "position": {
-        "x": -186.7,
-        "y": 22
+        "x": -186.6,
+        "y": 21.7
       },
-      "properties": [
-        "OneWayDown",
-        "(2.9, 0.6)",
-        "(0, -0.3)"
-      ]
+      "scale": {
+        "x": 3.1,
+        "y": 0.6,
+        "z": 1
+      }
     },
     {
       "Type": "wasteland-stone-diagonal",

--- a/resources/levels/Lost Dreams/D01Z03S06.json
+++ b/resources/levels/Lost Dreams/D01Z03S06.json
@@ -47,6 +47,18 @@
       ]
     },
     {
+      "Type": "boxcollider",
+      "position": {
+        "x": -186.7,
+        "y": 22
+      },
+      "properties": [
+        "OneWayDown",
+        "(2.9, 0.6)",
+        "(0, -0.3)"
+      ]
+    },
+    {
       "Type": "wasteland-stone-diagonal",
       "position": {
         "x": -154.94,
@@ -173,8 +185,8 @@
         "z": 1
       },
       "position": {
-        "x": -152.7,
-        "y": 15.45
+        "x": -157.2,
+        "y": 14
       },
       "properties": [
         "__square",
@@ -191,8 +203,8 @@
         "z": 1
       },
       "position": {
-        "x": -151,
-        "y": 17.7
+        "x": -154,
+        "y": 16
       },
       "properties": [
         "__square",
@@ -256,20 +268,8 @@
         "y": 18
       },
       "properties": [
-        "false",
-        "BP04"
-      ]
-    },
-    {
-      "Type": "platform-blood",
-      "Id": "BP01",
-      "position": {
-        "x": -187,
-        "y": 22
-      },
-      "properties": [
         "true",
-        "BP02"
+        "BP04"
       ]
     },
     {


### PR DESCRIPTION
- repositioned filling blocks in D01Z03S06
- added a filling block in the door transition in D01Z03S04 to prevent penitent being seen during room transition trigger
- added a `"boxcollider"` object creator
- modified `BoxColliderModifier` and `BaseColliderModifier` to be able to intialize themselves through properties in JSON file (customizable size/offset/layer)